### PR TITLE
Fix runHacx title

### DIFF
--- a/runhacx.html
+++ b/runhacx.html
@@ -28,7 +28,7 @@
 					<div><p>Type in a cheatcode or command and the system will attempt running it for you.</p></div>
 				</section>
 				<section>
-					<div><u>O</u>pen:</div>
+					<div><u>E</u>xecute:</div>
 					<div>
 						<input type="text" name="input" autocomplete="off" />
 					</div>


### PR DESCRIPTION
The runhacx.html said "Open", while the real game says "Execute".